### PR TITLE
Update compile steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ KERNEL=="ttyACM[0-9]",MODE="0666"
 
 Compile steps:
 ```sh
-git clone git.kde.org:brprint3d
+sudo apt-get install git cmake g++ # On debian, Ubuntu, etc.
+git clone https://github.com/KDE/brprint3d.git
+cd brprint3d
 mkdir build
 cd build
 cmake ..


### PR DESCRIPTION
The instructions were missing the build-time dependencies and most people got permissions denied when trying to clone from git.kde.org:brprint3d. Also a `cd` was missing.
